### PR TITLE
Add 16 second delay to low power sleep example

### DIFF
--- a/SavePowerSleeping.md
+++ b/SavePowerSleeping.md
@@ -18,6 +18,7 @@ The usage is quite simple:
 void setup() {
   pinMode(LED_BUILTIN, OUTPUT);
   digitalWrite(LED_BUILTIN, HIGH);
+  delay(16000);
 }
 
 void loop() {


### PR DESCRIPTION
It's not possible to reprogram the Arduino in the 5 second window in the loop() method with the Arduino IDE (Windows or Linux).
Adding a 16 second delay at the start should hopefully allow people trying this example to program their Arduinos immediately after resetting them.

Hopefully I'll be able to use a different programmer to program my Nano 33 IoT again.